### PR TITLE
メッセージ送信機能を非同期通信化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ group :development, :test do
   gem "factory_bot_rails"
   gem "faker"
   gem "rails-controller-testing"
+
+  gem 'pry-rails'
+  gem 'pry-byebug'
+  gem 'pry-doc'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       image_processing (~> 1.1)
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -137,6 +138,17 @@ GEM
     pastel (0.7.3)
       equatable (~> 0.6)
       tty-color (~> 0.5)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-doc (1.0.0)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (3.1.0)
     puma (3.12.1)
     rack (2.0.7)
@@ -257,6 +269,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    yard (0.9.19)
 
 PLATFORMS
   ruby
@@ -276,6 +289,9 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-byebug
+  pry-doc
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,8 @@
+$(function(){
+
+  $(".new_message").on("submit",function(e){
+    e.preventDefault();
+    console.log("ok!")
+
+  });
+});

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -41,7 +41,9 @@ $(function(){
     })
     .done(function(data){
       appendMessage(data);
+      $(".form__message").val("");
       $(".chat__main").animate({scrollTop: $(".chat__main")[0].scrollHeight},100,"swing");
+      $(".form__submit").attr("disabled",false);
     })
 
   });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,5 +1,31 @@
 $(function(){
 
+  var chat__main=$(".chat__main");
+
+
+  function appendMessage(message){
+    var content = message.content ? `${ message.content }` : "";
+    var image = message.image ? `<img src="${ message.image }" width="200" height="200">` : "";
+ 
+    var html =`
+    <div class="chat__main__message">
+      <div class="chat__main__message__name">
+        ${message.user_name}
+      </div>
+      <div class="chat__main__message--gray">
+        ${message.created_at}
+      </div>
+      <div class="chat__main__message__text">
+        ${content}
+        ${image}
+      </div>
+    </div>`;
+
+    chat__main.append(html);
+  };
+
+
+
   $(".new_message").on("submit",function(e){
     e.preventDefault();
 
@@ -13,7 +39,9 @@ $(function(){
       processData: false,
       contentType: false
     })
-
+    .done(function(data){
+      appendMessage(data);
+    })
 
   });
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -42,6 +42,7 @@ $(function(){
     .done(function(data){
       appendMessage(data);
       $(".form__message").val("");
+      $(".hidden").val("");
       $(".chat__main").animate({scrollTop: $(".chat__main")[0].scrollHeight},100,"swing");
       $(".form__submit").attr("disabled",false);
     })

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -45,6 +45,8 @@ $(function(){
       $(".chat__main").animate({scrollTop: $(".chat__main")[0].scrollHeight},100,"swing");
       $(".form__submit").attr("disabled",false);
     })
-
+    .fail(function(){
+      window.alert("メッセージを送信できませんでした…");
+    })
   });
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -41,6 +41,7 @@ $(function(){
     })
     .done(function(data){
       appendMessage(data);
+      $(".chat__main").animate({scrollTop: $(".chat__main")[0].scrollHeight},100,"swing");
     })
 
   });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -2,7 +2,18 @@ $(function(){
 
   $(".new_message").on("submit",function(e){
     e.preventDefault();
-    console.log("ok!")
+
+    var formData= new FormData(this);
+    var url= $(this).attr("action");
+    $.ajax({
+      type: "POST",
+      url: url,
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    })
+
 
   });
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -48,6 +48,7 @@ $(function(){
     })
     .fail(function(){
       window.alert("メッセージを送信できませんでした…");
+      $(".form__submit").attr("disabled",false);
     })
   });
 });

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -41,8 +41,7 @@ $(function(){
     })
     .done(function(data){
       appendMessage(data);
-      $(".form__message").val("");
-      $(".hidden").val("");
+      $(".new_message")[0].reset();
       $(".chat__main").animate({scrollTop: $(".chat__main")[0].scrollHeight},100,"swing");
       $(".form__submit").attr("disabled",false);
     })

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,10 @@ class MessagesController < ApplicationController
   def create
     @message=@group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group),notice: "メッセージが送信されました"
+      respond_to do |format|
+        format.html {redirect_to group_messages_path(params[:group_id])}
+        format.json
+      end
     else
       @messages=@group.messages.includes(:user)
       flash.now[:alert]="メッセージを入力してください" 

--- a/app/views/messages/_message.haml
+++ b/app/views/messages/_message.haml
@@ -5,3 +5,5 @@
     = message.created_at.strftime("%Y/%m/%d %H:%M")
   .chat__main__message__text
     = message.content
+    - if message.image?
+      = image_tag  message.image, size: "200x200"

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content        message.content
+  json.image          message.image
+  json.message_id     message.id
+  json.created_at     message.created_at
+  json.user_name      message.users.name
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,7 +1,6 @@
-json.array! @messages do |message|
-  json.content        message.content
-  json.image          message.image
-  json.message_id     message.id
-  json.created_at     message.created_at
-  json.user_name      message.users.name
-end
+
+json.content        @message.content
+json.image          @message.image.url
+json.created_at     @message.created_at.strftime("%Y/%m/%d %H:%M")
+json.user_name      @message.user.name
+json.id             @message.id

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# what
メッセージ送信を非同期通信でできるようにする。

# why
非同期通信をメッセージ機能に実装することで、メッセージを送るたびにページのリダイレクトが行われる処理を簡易化できるから。